### PR TITLE
Fix calendar iframe clipping on desktop view

### DIFF
--- a/cal.html
+++ b/cal.html
@@ -37,7 +37,13 @@
         margin: 0;
         font-size: 1rem;
       }
-      .owc-frame { flex: 1; width: 100%; border: 0; background: #0b0f14; }
+      .owc-frame {
+        flex: 1;
+        width: calc(100% + 2px);
+        margin-left: -1px;
+        border: 0;
+        background: #0b0f14;
+      }
       .desktop-info-btn {
         padding: .4rem .6rem;
         border: 1px solid rgba(255,255,255,.16);


### PR DESCRIPTION
## Summary
- Expand Open Web Calendar iframe width and offset it left to prevent the left edge from being clipped

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6897bc78c5fc83339a2016fd90efe2d9